### PR TITLE
Add tokens for base branch and tail of base branch

### DIFF
--- a/src/branch-details-form/branch-details-form.tsx
+++ b/src/branch-details-form/branch-details-form.tsx
@@ -122,7 +122,7 @@ class BranchDetailsForm extends React.Component<{}, ISelectBranchDetailsState> {
             const branchCreator = new BranchCreator();
             let branchNames: string[] = [];
             for await (const workItemId of this.state.workItems) {
-                const branchName = await branchCreator.getBranchName(workItemTrackingRestClient, settingsDocument, workItemId, this.state.projectName!);
+                const branchName = await branchCreator.getBranchName(workItemTrackingRestClient, settingsDocument, workItemId, this.state.projectName!, this.state.sourceBranchName!);
                 branchNames.push(branchName);
             }
 

--- a/src/branchNameTemplateValidator.tsx
+++ b/src/branchNameTemplateValidator.tsx
@@ -38,6 +38,9 @@ export class BranchNameTemplateValidator {
     }
 
     private getUnknownFields(tokens: string[], workItemFieldNames: string[]): string[] {
+        const allFieldNames = Object.assign([], workItemFieldNames)
+        allFieldNames.push("SourceBranchName")
+        allFieldNames.push("SourceBranchNameTail")
         const fieldNames = tokens.map(token => token.replace('${', '').replace('}', ''));
         return fieldNames.filter(x => workItemFieldNames.indexOf(x) === -1);
     }


### PR DESCRIPTION
Add tokens to use the `SourceBranchName` (e.g. `main`) or `SourceBranchNameTail`  (part after the last `/`) in the branch name template.

I'm not able to test it on my organisation because of permission problem to install extensions.