### PR TITLE
Fix selection of source branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,23 @@
 Use Easy Branch Creator in Azure DevOps to create branches directly from within workitems using fields from the workitem for the branch name.
 
 ## Overview
-When you want to create a new branch, it is often good to have a branch naming convention in place. With the convention in place, branches are more structure and it's easier to find the correct branch. You can group branches also in subfolders based on a category like *feature* or *bugfix*.  
-In Azure DevOps you often create a branch on the basis of a workitem and then use some information from the workitem for the name of the branch. To be able to do so, you often need to copy several fields of the workitem to construct the actual branch name.  
+When you want to create a new branch, it is often good to have a branch naming convention in place. With the convention in place, branches are more structure and it's easier to find the correct branch. You can group branches also in subfolders based on a category like *feature* or *bugfix*.
+In Azure DevOps you often create a branch on the basis of a workitem and then use some information from the workitem for the name of the branch. To be able to do so, you often need to copy several fields of the workitem to construct the actual branch name.
 
 ### Create branch
-The `easy-branch-creator` is an extension for Azure DevOps that eases this process. `easy-branch-creator` adds a menu action on a workitem to automatically create a branch using fields from the given workitem.  
+The `easy-branch-creator` is an extension for Azure DevOps that eases this process. `easy-branch-creator` adds a menu action on a workitem to automatically create a branch using fields from the given workitem.
 When clicking the actions, `easy-branch-creator` will create a new branch, using the configured naming convention, based on the default branch.
 
 ![Create Branch Screen Shot][create-branch-action]
 
 ### Settings
-`easy-branch-creator` can be configured in several ways. The settings can be found in `Project Settings` under the `Extensions` section. 
+`easy-branch-creator` can be configured in several ways. The settings can be found in `Project Settings` under the `Extensions` section.
 - Template Branch Name
-  - This is the template being used to create the branch name. The template can use **any** field from a workitem. Validation is in place to ensure a valid template is entered.
+  - This is the template being used to create the branch name. The template can use **any** field from a workitem plus the following ones:
+    - `SourceBranchName`: The name of the selected source branch.
+    - `SourceBranchNameWithReplacement`: The name of the selected source branch with all non alpha numerical characters are replaced.
+    - `SourceBranchNameTail`: The part after the last `/` of source branch name. If source branch doesn't contain a `/` the full name is used.
+  - Validation is in place to ensure a valid template is entered.
 - Non-alphanumeric characters replacement
   - Any non-alphanumeric character in a workitem field will be replaced by this character.
 - Lowercase branch name

--- a/src/branch-creator.tsx
+++ b/src/branch-creator.tsx
@@ -71,7 +71,7 @@ export class BranchCreator {
         tokens.forEach((token) => {
             let workItemFieldName = token.replace('${', '').replace('}', '');
             let workItemFieldValue = ""
-            if (workItemFieldName == "SourceBranchName") {
+            if ((workItemFieldName == "SourceBranchName") || (workItemFieldName == "SourceBranchNameWithReplacement")) {
                 workItemFieldValue = sourceBranchName
             }
             else if (workItemFieldName == "SourceBranchNameTail") {
@@ -82,7 +82,7 @@ export class BranchCreator {
             }
 
             if (workItemFieldValue) {
-                if (typeof workItemFieldValue.replace === 'function') {
+                if ((typeof workItemFieldValue.replace === 'function') && (workItemFieldName != "SourceBranchName")) {
                     workItemFieldValue = workItemFieldValue.replace(/[^a-zA-Z0-9]/g, settingsDocument.nonAlphanumericCharactersReplacement);
                 }
             }

--- a/src/branch-details-form/branch-details-form.tsx
+++ b/src/branch-details-form/branch-details-form.tsx
@@ -44,8 +44,6 @@ class BranchDetailsForm extends React.Component<{}, ISelectBranchDetailsState> {
 
             this.setState({ projectName: config.projectName, workItems: config.workItems, selectedRepositoryId: config.initialValue, ready: false, branchNames: [] });
 
-            await this.setBranchNames();
-
             this.setState(prevState => ({
                 ...prevState,
                 ready: true
@@ -111,7 +109,13 @@ class BranchDetailsForm extends React.Component<{}, ISelectBranchDetailsState> {
             ...prevState,
             sourceBranchName: newBranchName
         }));
-    }
+        // Update the branch name
+        this.setBranchNames();
+        this.setState(prevState => ({
+            ...prevState,
+            ready: true
+        }));
+}
 
     private async setBranchNames() {
         if (this.state.projectName) {

--- a/src/branchNameTemplateValidator.tsx
+++ b/src/branchNameTemplateValidator.tsx
@@ -40,6 +40,7 @@ export class BranchNameTemplateValidator {
     private getUnknownFields(tokens: string[], workItemFieldNames: string[]): string[] {
         const allFieldNames = Object.assign([], workItemFieldNames)
         allFieldNames.push("SourceBranchName")
+        allFieldNames.push("SourceBranchNameWithReplacement")
         allFieldNames.push("SourceBranchNameTail")
         const fieldNames = tokens.map(token => token.replace('${', '').replace('}', ''));
         return fieldNames.filter(x => allFieldNames.indexOf(x) === -1);

--- a/src/branchNameTemplateValidator.tsx
+++ b/src/branchNameTemplateValidator.tsx
@@ -42,6 +42,6 @@ export class BranchNameTemplateValidator {
         allFieldNames.push("SourceBranchName")
         allFieldNames.push("SourceBranchNameTail")
         const fieldNames = tokens.map(token => token.replace('${', '').replace('}', ''));
-        return fieldNames.filter(x => workItemFieldNames.indexOf(x) === -1);
+        return fieldNames.filter(x => allFieldNames.indexOf(x) === -1);
     }
 }


### PR DESCRIPTION
- The check of the variable reference wasn't reflecting the added variables.
- The branch name in the creation dialog is always showing `undefined` instead of the selected value.
- Non alphanumeric characters in `SourceBranchName` were always replaced. This is not the case anymore but the additional variable `SourceBranchNameWithReplacement` is added.

Also the REDME.md is updated with the additional variables.

Fixes #21 